### PR TITLE
Add show and hide methods as a core method

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,5 +66,7 @@ export default class FlashMessages {
 
 - find
 - findAll
+- show
+- hide
 - redirectTo
 - submit

--- a/src/controller.js
+++ b/src/controller.js
@@ -9,6 +9,14 @@ export default class Controller {
     return document.querySelectorAll(query)
   }
 
+  show(query) {
+    find(query).setAttribute('style', '');
+  }
+
+  hide(query) {
+    find(query).setAttribute('style', 'display: none');
+  }
+
   redirectTo(url) {
     if (Turbolinks !== 'undefined')
       Turbolinks.visit(url)


### PR DESCRIPTION
## New methods

I think that this methods are enough useful to have it into the core framework.
- `show(query)`
- `hide(query)`

**Use**
```
show('#element_id')

hide('.element_query')
```

**Response Error**
- Raise error if element does not exist
```
Uncaught TypeError: Cannot read property 'setAttribute' of null
```
