### PR TITLE
Add URL params and hash methods to core

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,13 @@ export default class FlashMessages {
 - currentUrl()
 - getParam(param)
 - setParam(param, value, url)
+- replaceState(state, data)
+- pushState(state, data)
+- replaceURLHash(value)
+- replaceURLParams(params)
+- appendURLParam(param, value)
+- setURLParam(param, value)
+- deleteURLParam(param)
 
 ### Events
 

--- a/README.md
+++ b/README.md
@@ -194,14 +194,8 @@ export default class FlashMessages {
 - visit(url)
 - currentUrl()
 - getParam(param)
-- setParam(param, value, url)
-- replaceState(state, data)
-- pushState(state, data)
-- replaceURLHash(value)
-- replaceURLParams(params)
-- appendURLParam(param, value)
-- setURLParam(param, value)
-- deleteURLParam(param)
+- setParam(param, value, { url, update })
+- setUrl(state, method, data)
 
 ### Events
 

--- a/src/core.js
+++ b/src/core.js
@@ -75,10 +75,11 @@ export default class Core {
       return urlParams.get(param)
   }
 
-  setParam(param, value, url = currentUrl()) {
+  setParam(param, value, { url = currentUrl(), update = false } = {}) {
     const urlParams = new URL(url)
     urlParams.searchParams.set(param, value)
 
+    if (update) self.setUrl(urlParams.href)
     return urlParams.href
   }
 
@@ -132,41 +133,14 @@ export default class Core {
       return query
   }
 
-  replaceState(state, data = {}) {
-    history.replaceState(data, undefined, state)
-  }
-
-  pushState(state, data = {}) {
-    history.pushState(data, undefined, state)
-  }
-
-  replaceURLHash(value) {
-    if (value.charAt(0) !== "#") value = "#" + value
-    this.replaceState(value)
-  }
-
-  replaceURLParams(params) {
-    const hash = window.location.hash
-    if (params.charAt(0) !== "?") params = "?" + params
-    this.replaceState(params)
-    this.replaceURLHash(hash)
-  }
-
-  appendURLParam(param, value) {
-    const params = new URLSearchParams(window.location.search)
-    params.append(param, value);
-    this.replaceURLParams(params.toString())
-  }
-
-  setURLParam(param, value) {
-    const params = new URLSearchParams(window.location.search)
-    params.set(param, value);
-    this.replaceURLParams(params.toString())
-  }
-
-  deleteURLParam(param) {
-    const params = new URLSearchParams(window.location.search)
-    params.delete(param)
-    this.replaceURLParams(params.toString())
+  setUrl(state, method = 'push', data = {}) {
+    switch (method) {
+      case "push":
+        history.pushState(data, undefined, state)
+        break
+      case "replace":
+        history.replaceState(data, undefined, state)
+        break
+    }
   }
 }

--- a/src/core.js
+++ b/src/core.js
@@ -79,7 +79,7 @@ export default class Core {
     const urlParams = new URL(url)
     urlParams.searchParams.set(param, value)
 
-    if (update) self.setUrl(urlParams.href)
+    if (update) setUrl(urlParams.href)
     return urlParams.href
   }
 

--- a/src/core.js
+++ b/src/core.js
@@ -131,4 +131,42 @@ export default class Core {
     else
       return query
   }
+
+  replaceState(state, data = {}) {
+    history.replaceState(data, undefined, state)
+  }
+
+  pushState(state, data = {}) {
+    history.pushState(data, undefined, state)
+  }
+
+  replaceURLHash(value) {
+    if (value.charAt(0) !== "#") value = "#" + value
+    this.replaceState(value)
+  }
+
+  replaceURLParams(params) {
+    const hash = window.location.hash
+    if (params.charAt(0) !== "?") params = "?" + params
+    this.replaceState(params)
+    this.replaceURLHash(hash)
+  }
+
+  appendURLParam(param, value) {
+    const params = new URLSearchParams(window.location.search)
+    params.append(param, value);
+    this.replaceURLParams(params.toString())
+  }
+
+  setURLParam(param, value) {
+    const params = new URLSearchParams(window.location.search)
+    params.set(param, value);
+    this.replaceURLParams(params.toString())
+  }
+
+  deleteURLParam(param) {
+    const params = new URLSearchParams(window.location.search)
+    params.delete(param)
+    this.replaceURLParams(params.toString())
+  }
 }

--- a/src/core.js
+++ b/src/core.js
@@ -126,13 +126,6 @@ export default class Core {
     }
   }
 
-  _element(query) {
-    if (typeof query === 'string')
-      return find(query)
-    else
-      return query
-  }
-
   setUrl(state, method = 'push', data = {}) {
     switch (method) {
       case "push":
@@ -142,5 +135,12 @@ export default class Core {
         history.replaceState(data, undefined, state)
         break
     }
+  }
+
+  _element(query) {
+    if (typeof query === 'string')
+      return find(query)
+    else
+      return query
   }
 }


### PR DESCRIPTION
Add methods to help working with the location.

Closes #18 

**USAGE**
Add (or replace) the hash value without creating a new history entry:
```
setUrl("#info", "replace");
```
Add (or replace) the hash value creating a new history entry:
```
setUrl("#info");
```
Return the URL as string with the given pair added: 
```
setParam("a", "a")
```
Return the URL as string with the given pair added and update the current URL: 
```
setParam("a", "a",  { update: true })
```