### PR TITLE
Support multiple attributes in "Attributes" methods

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -123,30 +123,35 @@ export default class Core {
     const el = _element(query)
     if (!el) return
 
-    if (attribute instanceof String){
+    if (typeof attribute === 'string')
       if (value === undefined)
         return el.getAttribute(attribute)
       else
         return el.setAttribute(attribute, value)
-    } else if (attribute instanceof Object){
+    else if (typeof attribute  === 'object')
       Object.entries(attribute).forEach(entry => {
         let k = entry[0];
         let v = entry[1];
         el.setAttribute(k, v)
       });
-    }
   }
 
   data(query, attribute, value) {
     const el = _element(query)
     if (!el) return
+    if (attribute === undefined && value === undefined) return el.dataset
 
-    if (attribute != undefined && value != undefined)
-      return el.dataset[attribute] = value
-    else if (attribute != undefined)
-      return el.dataset[attribute]
-    else
-      return el.dataset
+    if (typeof attribute === 'string')
+      if (value === undefined)
+        return el.dataset[attribute]
+      else
+        return el.dataset[attribute] = value
+    else if (typeof attribute  === 'object')
+      Object.entries(attribute).forEach(entry => {
+        let k = entry[0]
+        let v = entry[1]
+        return el.dataset[k] = v
+      })
   }
 
   setUrl(state, method = 'push', data = {}) {

--- a/src/core.js
+++ b/src/core.js
@@ -123,10 +123,18 @@ export default class Core {
     const el = _element(query)
     if (!el) return
 
-    if (value == undefined)
-      return el.getAttribute(attribute)
-    else
-      return el.setAttribute(attribute, value)
+    if (attribute instanceof String){
+      if (value === undefined)
+        return el.getAttribute(attribute)
+      else
+        return el.setAttribute(attribute, value)
+    } else if (attribute instanceof Object){
+      Object.entries(attribute).forEach(entry => {
+        let k = entry[0];
+        let v = entry[1];
+        el.setAttribute(k, v)
+      });
+    }
   }
 
   data(query, attribute, value) {

--- a/src/core.js
+++ b/src/core.js
@@ -130,8 +130,8 @@ export default class Core {
         return el.setAttribute(attribute, value)
     else if (typeof attribute  === 'object')
       Object.entries(attribute).forEach(entry => {
-        let k = entry[0];
-        let v = entry[1];
+        const k = entry[0];
+        const v = entry[1];
         el.setAttribute(k, v)
       });
   }
@@ -148,8 +148,8 @@ export default class Core {
         return el.dataset[attribute] = value
     else if (typeof attribute  === 'object')
       Object.entries(attribute).forEach(entry => {
-        let k = entry[0]
-        let v = entry[1]
+        const k = entry[0]
+        const v = entry[1]
         return el.dataset[k] = v
       })
   }


### PR DESCRIPTION
Allow multiple attributes as params in attributes methods.

Closes https://github.com/ralixjs/ralix/issues/26

**Examples:**
```
attr('.target', { a: 1, b: 2 })
```
```
data('.target', { a: 1, b: 2 })
```