### PR TITLE
Components: use static method onload() instead of constructor()

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Structure:
 ├── components
 │   ├── modal.js
 │   ├── geolocation.js
-│   ├── flash_messages.js
 │   ├── forms.js
 ├── controllers
 │   ├── users.js
@@ -68,7 +67,7 @@ import UsersCtrl     from 'controllers/users'
 
 // Components with auto-start on each DOM load event (turbolinks:load or DOMContentLoaded)
 import Forms         from 'components/forms'
-import FlashMessages from 'components/flash_messages'
+import Modal         from 'components/modal'
 
 const App = new RalixApp({
   rails_ujs: Rails,
@@ -78,10 +77,7 @@ const App = new RalixApp({
     '/users':     UsersCtrl,
     '/.*':        AppCtrl
   },
-  components: [
-    Forms,
-    FlashMessages
-  ]
+  components: [Forms, Modal]
 })
 
 Rails.start()

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Ralix provides barebones and utilities to help enhance your current Rails views.
 Ralix consists basically in 2 concepts, `Controllers` and `Components`:
 
 - `Controllers`: Controllers are meant to be mounted under a route path, they are like page-specific (scoped) JavaScript.
-- `Components`: Components are like widgets you will have in several pages: modals, tooltips, notifications, etc. Components can be also auto-mounted on each DOM load, you just need to pass them to the `RalixApp` instance.
+- `Components`: Components are like widgets you will have in several pages: modals, tooltips, notifications, etc. Components can be also auto-mounted on each DOM load, you just need to pass them to the `RalixApp` instance (and implement the static method `onload`).
 
 On the other hand, Ralix also provides some helpers and utilities to facilitate most common operations like: selectors, manipulations, events, etc. [Check it out here](#core-methods).
 
@@ -92,8 +92,6 @@ App.start()
 ### Controllers
 
 ```js
-import Modal from 'components/modal'
-
 export default class AppCtrl {
   back() {
     window.history.back()
@@ -101,11 +99,6 @@ export default class AppCtrl {
 
   toggleMenu() {
     toggleClass('#menu', 'hidden')
-  }
-
-  openModal(url) {
-    const modal = new Modal(url)
-    modal.show()
   }
 }
 ```
@@ -140,7 +133,7 @@ export default class UsersCtrl extends AppCtrl {
 <div id="menu">...</div>
 ...
 <a href="#" onclick="toggleMenu()">Toggle Menu</a>
-<a href="#" onclick="openModal('/modals/help')">Help me!</a>
+<a href="#" class="fire-modal" data-url="/modals/help">Help me!</a>
 ...
 <input type="text" name="query" onkeyup="search()" />
 ...
@@ -151,6 +144,15 @@ export default class UsersCtrl extends AppCtrl {
 
 ```js
 export default class Modal {
+  static onload() {
+    findAll('.fire-modal').forEach(el => {
+      on(el, 'click', () => {
+        const modal = new Modal(data(el, 'url'))
+        modal.show()
+      })
+    })
+  }
+
   constructor(url) {
     this.url = url
   }

--- a/README.md
+++ b/README.md
@@ -122,20 +122,6 @@ export default class UsersCtrl extends AppCtrl {
 }
 ```
 
-### Views
-
-```html
-<a href="#" onclick="back()">Back</a>
-<div id="menu">...</div>
-...
-<a href="#" onclick="toggleMenu()">Toggle Menu</a>
-<a href="#" class="fire-modal" data-url="/modals/help">Help me!</a>
-...
-<input type="text" name="query" onkeyup="search()" />
-...
-<div onclick="visit('/sign-up')">...</div>
-```
-
 ### Components
 
 ```js
@@ -174,6 +160,20 @@ export default class Modal {
     })
   }
 }
+```
+
+### Views
+
+```html
+<a href="#" onclick="back()">Back</a>
+<div id="menu">...</div>
+...
+<a href="#" onclick="toggleMenu()">Toggle Menu</a>
+<a href="#" class="fire-modal" data-url="/modals/help">Help me!</a>
+...
+<input type="text" name="query" onkeyup="search()" />
+...
+<div onclick="visit('/sign-up')">...</div>
 ```
 
 ### Templates

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -44,7 +44,7 @@ export default class Tooltip {
     ...
   }
 }
-````
+```
 
 ## Utilities
 

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -28,7 +28,23 @@ routes: {
 
 The Components are designed to encapsulate code for widgets you will have in several pages: modals, tooltips, forms, etc.
 
-Components can be also auto-mounted on each DOM load, you just need to pass them to the `RalixApp` instance and Ralix will call the `constructor` method automatically.
+Components can be also auto-mounted on each DOM load, you just need to pass them to the `RalixApp` instance and Ralix will call the `onload` static method automatically. Example:
+
+```js
+export default class Tooltip {
+  static onload() {
+    findAll('.tooltip').forEach(el => {
+      on(el, 'click', () => {
+        new Tooltip(data(el))
+      })
+    })
+  }
+
+  constructor(options = {}) {
+    ...
+  }
+}
+````
 
 ## Utilities
 

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -34,7 +34,7 @@ Components can be also auto-mounted on each DOM load, you just need to pass them
 export default class Tooltip {
   static onload() {
     findAll('.tooltip').forEach(el => {
-      on(el, 'click', () => {
+      on(el, 'mouseover', () => {
         new Tooltip(data(el))
       })
     })

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -32,8 +32,8 @@ Components can be also auto-mounted on each DOM load, you just need to pass them
 
 ## Utilities
 
-Utilities, aka Core methods, are helpers to help you write most common operations with a nicer and shorter API: finders, manage classes, manage elements attributes and data-attributes, submit forms, change browser history, events and more. You can find all helpers documentation [here](CORE_API.md).
+Utilities, aka Core methods, are helpers to help you write most common operations with a nicer and shorter API: finders, manage classes, manage elements attributes and data-attributes, submit forms, change browser history, listeners and more. You can find all helpers documentation [here](CORE_API.md).
 
 ## Logo
 
-We use a bear, a sloth bear, inspired by Baloo (from The Jungle Book) performing the song "The Bare Necessities".
+We use a bear, a sloth bear, inspired by **Baloo** (from **The Jungle Book**) performing the song **The Bare Necessities**.

--- a/src/app.js
+++ b/src/app.js
@@ -21,13 +21,13 @@ export default class App {
   }
 
   start() {
-    const onLoad = (typeof Turbolinks !== 'undefined') ? 'turbolinks:load' : 'DOMContentLoaded'
+    const loadEvent = (typeof Turbolinks !== 'undefined') ? 'turbolinks:load' : 'DOMContentLoaded'
 
-    document.addEventListener(onLoad, () => {
+    document.addEventListener(loadEvent, () => {
       this.core.inject()
       this.router.dispatch()
       this.events.bind()
-      this.components.forEach(component => new(component))
+      this.components.forEach(component => component.onload())
     })
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -27,7 +27,10 @@ export default class App {
       this.core.inject()
       this.router.dispatch()
       this.events.bind()
-      this.components.forEach(component => component.onload())
+      this.components.forEach(component => {
+        if (typeof component.onload === 'function')
+          component.onload()
+      })
     })
   }
 }


### PR DESCRIPTION
This allows a more convenient API: keep the constructor to create the component and use `onload` to bind it automatically to the DOM. Example:

```js
export default class Modal {
  static onload() {
    findAll('.fire-modal').forEach(el => {
      on(el, 'click', () => {
        const modal = new Modal(data(el, 'url'))
        modal.show()
      })
    })
  }

  constructor(url) {
    this.url = url
  }

  show() { ... }
  
}
```

This is a "breaking" change :(, so better to do it asap, btw the fix is trivial: rename current `constructor()` to `static onload()`.