### PR TITLE
findAll should return array for single element too

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -19,9 +19,11 @@ export default class Core {
     if (query == null) return []
 
     let elements = (typeof query === 'string') ? document.querySelectorAll(query) : query
-    if (elements.length == undefined) elements = [elements]
 
-    return elements
+    if (Array.isArray(elements) || NodeList.prototype.isPrototypeOf(elements))
+      return elements
+    else
+      return [elements]
   }
 
   show(query) {


### PR DESCRIPTION
If you send one element to the findAll function, it's going to return the same one **without an array** since `element.length` is not going to return `undefined`. ref: https://github.com/ralixjs/ralix/blob/master/src/core.js#L21

Example:
```js
find('#new_user')
<form id="new_user" class="js-form" action="/users/sign_in" accept-charset="UTF-8" method="post" data-remote="true" data-bound="true">
find('#new_user').length
4
```