### PR TITLE
Allow ajax method to receive params as formData

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -243,8 +243,13 @@ export default class Helpers {
     const defaults = { method: 'GET', credentials: 'include' }
     options = Object.assign({}, defaults, options)
 
-    if (['POST', 'PATCH', 'PUT'].includes(options.method))
-      options = Object.assign({}, { body: JSON.stringify(params) }, options)
+    if (['POST', 'PATCH', 'PUT'].includes(options.method)) {
+      if (params instanceof FormData) {
+        if ("headers" in options) delete options.headers["Content-Type"]
+        options = Object.assign({}, { body: params }, options)
+      } else
+        options = Object.assign({}, { body: JSON.stringify(params) }, options)
+    }
     else if (Object.keys(params).length > 0)
       path = `${path}?${serialize(params)}`
 


### PR DESCRIPTION
Closes https://github.com/ralixjs/ralix/issues/53

**Use**
```
ajax(path, { params: FormData, options: options })
```

**Notes**

- When sending FormData if any Content-Type header will be removed.
- FormData will only work for `POST`, `PATCH` and `PUT` methods.