### PR TITLE
Fix _classModifier to be able to handle array of classes

### DIFF
--- a/docs/HELPERS_API.md
+++ b/docs/HELPERS_API.md
@@ -35,11 +35,23 @@ Adds `display: none` to the given element.
 
 ### `addClass(query, classList)`
 
-Wraps `classList.add`. The parameter _query_ could be also an array of elements.
+Wraps `classList.add`. The parameter _query_ could be also an array of elements. The parameter _classList_ can be a string or array of strings.
+
+```js
+> addClass('#target', 'class')
+
+> addClass('#target', ['class_one', 'class_two'])
+```
 
 ### `removeClass(query, classList)`
 
-Wraps `classList.remove`. The parameter _query_ could be also an array of elements.
+Wraps `classList.remove`. The parameter _query_ could be also an array of elements. The parameter _classList_ can be a string or array of strings.
+
+```js
+> removeClass('#target', 'class')
+
+> removeClass('#target', ['class_one', 'class_two'])
+```
 
 ### `toggleClass(query, classList)`
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -280,7 +280,10 @@ export default class Helpers {
       if (elements.length == 0) return
 
       elements.forEach(el => {
-        el.classList[operation](classList)
+        if (Array.isArray(classList))
+          el.classList[operation](...classList)
+        else
+          el.classList[operation](classList)
       })
     })
   }


### PR DESCRIPTION
**PROBLEM**

While we were using classList `add` and `remove` methods that can handle multiple classes at the same time it was not possible to do through `addClass` and `removeClass`.

**PROPOSED SOLUTION**

Be able to pass an array of classes to `addClass` and `removeClass`.

**EXAMPLE**

```
addClass("#target", ["class_one", "class_two"])
```

**NOTES**

While `toggle` can only receive one class, with this changes when given an array will only add (not remove) the first class. Before it will join all elements in the array with ',' and add it as a class. So IMO it's a better behavior than before.