### PR TITLE
[helpers] add support for requestSubmit

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ const App = new RalixApp({
   templates: Templates
 })
 
+// Define your template
 export const itemCard = ({ title, description }) => `
   <div class="item-card">
     <h1>${title}</h1>

--- a/docs/HELPERS_API.md
+++ b/docs/HELPERS_API.md
@@ -164,7 +164,7 @@ serialize({ x: "1", y: "2" })
 
 ### `submit(query)`
 
-If `rails_ujs` is provided in `new RalixApp()`, submits the form via `Rails.fire`, otherwise uses regular submit event.
+If `rails_ujs` is provided in `new RalixApp()`, submits the form via `Rails.fire`, otherwise uses `requestSubmit` (if available) or `submit`.
 
 ## Navigation
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -73,6 +73,8 @@ export default class Helpers {
 
     if (App.rails_ujs && data(form, 'remote') === 'true')
       App.rails_ujs.fire(form, 'submit')
+    else if (form.requestSubmit)
+      form.requestSubmit()
     else
       form.submit()
   }

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -331,7 +331,7 @@ describe('Forms', () => {
   describe('submit', () => {
     beforeEach(() => {
       // Mock requestSubmit
-      HTMLFormElement.prototype.requestSubmit = () => {}
+      HTMLFormElement.prototype.requestSubmit = jest.fn()
     })
 
     describe('without rails_ujs', () => {
@@ -358,7 +358,7 @@ describe('Forms', () => {
           fire: jest.fn()
         }
       }
-      document.body.innerHTML = '<form id="form" data-remote="true"><input type="number" name="first" value="1"><input type="text" name="second" value="2"></form>'
+      document.body.innerHTML = '<form data-remote="true"><input type="number" name="first" value="1"></form>'
       const form = document.body.querySelector('form')
       // Mock submit function to prevent errors
       form.submit = jest.fn()

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -4,11 +4,9 @@ import Helpers from '../src/helpers'
 import { jest } from '@jest/globals'
 
 const helpers = new Helpers()
-let element, element2
+helpers.inject()
 
-beforeAll(() => {
-  helpers.inject()
-})
+let element, element2
 
 beforeEach(() => {
   element = document.createElement('div')
@@ -334,21 +332,17 @@ describe('Forms', () => {
       HTMLFormElement.prototype.requestSubmit = jest.fn()
     })
 
-    describe('without rails_ujs', () => {
-      test('defaults to requestSubmit if supported', () => {
-        // Mock App
-        window.App = {
-          rails_ujs: false
-        }
-        const form = document.body.querySelector('form')
-        // Mock submit function to prevent errors
-        form.submit = jest.fn()
-        const spy = jest.spyOn(form, 'requestSubmit')
+    test('without rails_ujs', () => {
+      // Mock App
+      window.App = {
+        rails_ujs: false
+      }
+      const form = document.body.querySelector('form')
+      const spy = jest.spyOn(form, 'requestSubmit')
 
-        submit('#form')
+      submit('#form')
 
-        expect(spy).toHaveBeenCalledTimes(1)
-      })
+      expect(spy).toHaveBeenCalledTimes(1)
     })
 
     test('with rails_ujs & data-remote', () => {
@@ -360,8 +354,6 @@ describe('Forms', () => {
       }
       document.body.innerHTML = '<form data-remote="true"><input type="number" name="first" value="1"></form>'
       const form = document.body.querySelector('form')
-      // Mock submit function to prevent errors
-      form.submit = jest.fn()
       const spy = jest.spyOn(form, 'requestSubmit')
 
       submit('#form')

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -1,6 +1,4 @@
-/**
- * @jest-environment jsdom
- */
+/* @jest-environment jsdom */
 
 import Helpers from '../src/helpers'
 import { jest } from '@jest/globals'
@@ -331,27 +329,26 @@ describe('Forms', () => {
   })
 
   describe('submit', () => {
-    beforeAll(() => {
-      delete window.App
+    beforeEach(() => {
+      // Mock requestSubmit
+      HTMLFormElement.prototype.requestSubmit = () => {}
     })
 
-    afterAll(() => {
-      delete window.App
-    })
+    describe('without rails_ujs', () => {
+      test('defaults to requestSubmit if supported', () => {
+        // Mock App
+        window.App = {
+          rails_ujs: false
+        }
+        const form = document.body.querySelector('form')
+        // Mock submit function to prevent errors
+        form.submit = jest.fn()
+        const spy = jest.spyOn(form, 'requestSubmit')
 
-    test('without rails_ujs', () => {
-      // Mock App
-      window.App = {
-        rails_ujs: false
-      }
-      const form = document.body.querySelector('form')
-      // Mock submit function to prevent errors
-      form.submit = jest.fn()
-      const spy = jest.spyOn(form, 'submit')
+        submit('#form')
 
-      submit('#form')
-
-      expect(spy).toHaveBeenCalledTimes(1)
+        expect(spy).toHaveBeenCalledTimes(1)
+      })
     })
 
     test('with rails_ujs & data-remote', () => {
@@ -361,12 +358,11 @@ describe('Forms', () => {
           fire: jest.fn()
         }
       }
-      document.body.innerHTML =
-        '<form id="form" data-remote="true"><input type="number" name="first" value="1"><input type="text" name="second" value="2"></form>'
+      document.body.innerHTML = '<form id="form" data-remote="true"><input type="number" name="first" value="1"><input type="text" name="second" value="2"></form>'
       const form = document.body.querySelector('form')
       // Mock submit function to prevent errors
       form.submit = jest.fn()
-      const spy = jest.spyOn(form, 'submit')
+      const spy = jest.spyOn(form, 'requestSubmit')
 
       submit('#form')
 

--- a/tests/templates.test.js
+++ b/tests/templates.test.js
@@ -1,11 +1,7 @@
 import Templates from '../src/templates'
 import * as ExampleTemplates from './fixtures/templates'
 
-let templates
-
-beforeAll(() => {
-  templates = new Templates(ExampleTemplates)
-})
+const templates = new Templates(ExampleTemplates)
 
 describe('render', () => {
   test('with correct template', () => {


### PR DESCRIPTION
This change makes Ralix to work nice with Turbo forms by default, and eventually (see **NOTE** below 👇🏼) we'll be able to delete the `rails_ujs` flag in a ~near future 🤘🏼

**NOTE** Some browsers still doesn't support it (https://caniuse.com/?search=requestSubmit), for example, recent Safari versions ... The cool thing is that using the requestSubmit api we can remove the `rails_ujs` thing and Rails remote forms still work as expected (tested on Chrome and Firefox ✅).