### PR TITLE
[events] preventDefault only links and buttons

### DIFF
--- a/docs/HELPERS_API.md
+++ b/docs/HELPERS_API.md
@@ -212,13 +212,15 @@ on('.input-submit', 'change keyup', (e) => {
 })
 ```
 
+**NOTE** `on` performs `preventDefault()` on `click` events for links, buttons and inputs.
+
 ### `currentElement()`
 
-Returns the element which received the last fired event.
+Returns the element which received the current fired event.
 
 ### `currentEvent()`
 
-Returns the last fired event.
+Returns the current event.
 
 ## Ajax
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -131,7 +131,7 @@ export default class Helpers {
 
   _addListener(elem, event, callback) {
     elem.addEventListener(event, (e) => {
-      if (event == 'click' && ['A' ,'BUTTON', 'INPUT'].includes(elem.tagName))
+      if (event == 'click' && ['A', 'BUTTON', 'INPUT'].includes(elem.tagName))
         e.preventDefault()
 
       App.currentElement = elem

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -129,12 +129,12 @@ export default class Helpers {
     return App.currentEvent
   }
 
-  _addListener(element, event, callback) {
-    element.addEventListener(event, (e) => {
-      if (event == 'click')
+  _addListener(elem, event, callback) {
+    elem.addEventListener(event, (e) => {
+      if (event == 'click' && ['A' ,'BUTTON', 'INPUT'].includes(elem.tagName))
         e.preventDefault()
 
-      App.currentElement = element
+      App.currentElement = elem
       App.currentEvent   = e
 
       callback.call(this, e)


### PR DESCRIPTION
This solves the following scenario:

```js
// add custom onclick for window or document
on(window, 'click', callback)
```

Then, links and buttons without a custom onclick stopped working on current page.

**SOLUTION** apply `preventDefault()` only for interactive elements.