### PR TITLE
[_addListener] Should preventDefault only 'submit' type for inputs

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -131,7 +131,7 @@ export default class Helpers {
 
   _addListener(elem, event, callback) {
     elem.addEventListener(event, (e) => {
-      if (event == 'click' && ['A', 'BUTTON', 'INPUT'].includes(elem.tagName))
+      if (event == 'click' && ['A', 'BUTTON'].includes(elem.tagName) || (elem.tagName == 'INPUT' && elem.type == 'submit'))
         e.preventDefault()
 
       App.currentElement = elem


### PR DESCRIPTION
We are preventing default events to be executed for inputs of any type, we should prevent only for 'submit' inputs