### PR TITLE
[FEAT] Back helper

### DIFF
--- a/docs/HELPERS_API.md
+++ b/docs/HELPERS_API.md
@@ -186,6 +186,10 @@ Reloads current page.
 
 Navigates to the given `url`, uses `Turbo.visit` (or `Turbolinks.visit`) if possible.
 
+### `back(fallbackUrl)`
+
+It returns the user to the previous page. If there is no previous page or the referrer has a different hostname than the current one it will use `visit(fallbackUrl)`.
+
 ### `currentUrl()`
 
 Returns the current location.

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -76,7 +76,12 @@ export default class Helpers {
   }
 
   back(fallbackUrl = null) {
-    history.length <= 1 && fallbackUrl ? this.visit(fallbackUrl) : history.back()
+    const isOtherHost = document.referrer != '' && !document.referrer.includes(location.hostname)
+
+    if ((history.length <= 1 || isOtherHost) && fallbackUrl != null)
+      this.visit(fallbackUrl)
+    else
+      history.back()
   }
 
   reload() {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -6,6 +6,7 @@ export default class Helpers {
       if (typeof this[method] === 'function' && method != 'inject')
         window[method] = this[method].bind(this)
     })
+    _manageSessionUrls()
   }
 
   find(query) {
@@ -73,6 +74,17 @@ export default class Helpers {
       Turbolinks.visit(url)
     else
       window.location.href = url
+  }
+
+  back(fallbackUrl = null) {
+    const previousPageAndCurrentPage = 2
+
+    if (sessionStorage.backCounter == '0') {
+      this.visit(fallbackUrl)
+    } else {
+      sessionStorage.backCounter = parseInt(sessionStorage.backCounter) - previousPageAndCurrentPage
+      history.back()
+    }
   }
 
   reload() {
@@ -326,5 +338,15 @@ export default class Helpers {
       const [key, value] = entry
       elem.dataset[key] = value
     })
+  }
+
+  _manageSessionUrls() {
+    const newPageVisited = 1
+    const isNotTheSamePage = sessionStorage.currentURL != location.href
+
+    if (!sessionStorage.backCounter) sessionStorage.backCounter = 0
+    if (sessionStorage.currentURL && isNotTheSamePage)
+      sessionStorage.backCounter = parseInt(sessionStorage.backCounter) + newPageVisited
+    sessionStorage.currentURL = location.href
   }
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -6,7 +6,6 @@ export default class Helpers {
       if (typeof this[method] === 'function' && method != 'inject')
         window[method] = this[method].bind(this)
     })
-    _manageSessionUrls()
   }
 
   find(query) {
@@ -77,14 +76,7 @@ export default class Helpers {
   }
 
   back(fallbackUrl = null) {
-    const previousPageAndCurrentPage = 2
-
-    if (sessionStorage.backCounter == '0') {
-      this.visit(fallbackUrl)
-    } else {
-      sessionStorage.backCounter = parseInt(sessionStorage.backCounter) - previousPageAndCurrentPage
-      history.back()
-    }
+    history.length <= 1 && fallbackUrl ? this.visit(fallbackUrl) : history.back()
   }
 
   reload() {
@@ -338,15 +330,5 @@ export default class Helpers {
       const [key, value] = entry
       elem.dataset[key] = value
     })
-  }
-
-  _manageSessionUrls() {
-    const newPageVisited = 1
-    const isNotTheSamePage = sessionStorage.currentURL != location.href
-
-    if (!sessionStorage.backCounter) sessionStorage.backCounter = 0
-    if (sessionStorage.currentURL && isNotTheSamePage)
-      sessionStorage.backCounter = parseInt(sessionStorage.backCounter) + newPageVisited
-    sessionStorage.currentURL = location.href
   }
 }

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -495,6 +495,38 @@ describe('Navigation', () => {
       expect(spyPush).toHaveBeenCalledTimes(0)
     })
   })
+
+  describe('back', () => {
+    beforeEach(() => {
+      window.location.href = 'http://test.com/'
+      window.location.hostname = 'test.com'
+    })
+
+    test('without history length', () => {
+      back('/back_fallback')
+
+      expect(window.location.href).toBe('/back_fallback')
+    })
+
+    test('with history length', () => {
+      jest.spyOn(history, 'length', 'get').mockReturnValue(3)
+      jest.spyOn(document, 'referrer', 'get').mockReturnValue('http://test.com/test')
+      const spyBack = jest.spyOn(history, 'back')
+
+      back('/back_fallback')
+
+      expect(spyBack).toHaveBeenCalledTimes(1)
+    })
+
+    test('with a different hostname', () => {
+      jest.spyOn(history, 'length', 'get').mockReturnValue(3)
+      jest.spyOn(document, 'referrer', 'get').mockReturnValue('http://other.com/')
+
+      back('/back_fallback')
+
+      expect(window.location.href).toBe('/back_fallback')
+    })
+  })
 })
 
 describe('Events', () => {


### PR DESCRIPTION
### Changes
- Now `back` can be used and also with a fallback (if the user accessed directly from URL).

closes #71