### PR TITLE
Ajax error handling

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -409,6 +409,8 @@ export default class Helpers {
         return response.json()
       else
         return response.text()
+    } catch (err) {
+      throw err
     }
   }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -379,11 +379,30 @@ export default class Helpers {
       path = `${path}?${serialize(params)}`
     }
 
-    const response = await fetch(path, options)
-    if (format.toLowerCase() === 'json')
-      return response.json()
-    else
-      return response.text()
+    try {
+      const response = await fetch(path, options)
+
+      if (!response.ok) {
+        let errorMessage = `HTTP error! Status: ${response.status}`
+
+        try {
+          const errorData = await response.json()
+          errorMessage = errorData.message || JSON.stringify(errorData)
+        }.catch (_) {}
+
+        const error = new Error(errorMessage)
+        error.status = response.status
+        error.response = response
+        throw error
+      }
+
+      if (format.toLowerCase() === 'json')
+        return response.json()
+      else
+        return response.text()
+    } catch (err) {
+      throw err
+    }
   }
 
   get(path, { params = {}, options = {} } = {}) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -388,7 +388,7 @@ export default class Helpers {
         try {
           const errorData = await response.json()
           errorMessage = errorData.message || JSON.stringify(errorData)
-        }.catch (_) {}
+        } catch (_) {}
 
         const error = new Error(errorMessage)
         error.status = response.status

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -370,7 +370,7 @@ export default class Helpers {
 
     if (['POST', 'PATCH', 'PUT'].includes(options.method)) {
       if (params instanceof FormData) {
-        if ("headers" in options) delete options.headers["Content-Type"]
+        if ("headers" in options && options.headers) delete options.headers["Content-Type"]
 
         options = Object.assign({}, { body: params }, options)
       } else
@@ -387,8 +387,17 @@ export default class Helpers {
 
         try {
           const errorData = await response.json()
-          errorMessage = errorData.message || JSON.stringify(errorData)
-        } catch (_) {}
+          if (errorData && errorData.message) {
+            errorMessage += ` - ${errorData.message}`;
+          } else {
+            errorMessage += ` - ${JSON.stringify(errorData)}`;
+          }
+        } catch (_) {
+          try {
+            const errorText = await response.text();
+            if (errorText) errorMessage += ` - ${errorText}`;
+          } catch (_) {}
+        }
 
         const error = new Error(errorMessage)
         error.status = response.status
@@ -400,8 +409,6 @@ export default class Helpers {
         return response.json()
       else
         return response.text()
-    } catch (err) {
-      throw err
     }
   }
 

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -809,7 +809,7 @@ describe('Ajax', () => {
         json: async () => { throw new Error('Not JSON') }
       })
 
-      await expect(ajax('http://example.com/')).rejects.toThrow(/HTTP error! Status: 404.*Internal Server Error/)
+      await expect(ajax('http://example.com/')).rejects.toThrow(/HTTP error! Status: 500.*Internal Server Error/)
     })
 
     test('error is catchable via .catch()', async () => {

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -794,10 +794,22 @@ describe('Ajax', () => {
         status: 404,
         statusText: 'Not Found',
         text: jest.fn().mockResolvedValue('Not Found'),
-        json: jest.fn().mockResolvedValue({})
+        json: jest.fn().mockResolvedValue({ message: 'Not Found' })
       })
 
-      await expect(ajax('http://example.com/')).rejects.toThrow('HTTP error! Status: 404')
+      await expect(ajax('http://example.com/')).rejects.toThrow(/HTTP error! Status: 404.*Not Found/)
+    })
+
+    test('rejects with error when response is not ok (status 500)', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        text: jest.fn().mockResolvedValue('Internal Server Error'),
+        json: async () => { throw new Error('Not JSON') }
+      })
+
+      await expect(ajax('http://example.com/')).rejects.toThrow(/HTTP error! Status: 404.*Internal Server Error/)
     })
 
     test('error is catchable via .catch()', async () => {

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -730,7 +730,7 @@ describe('Ajax', () => {
 
   beforeEach(() => {
     global.fetch = () => {
-      return { text: jest.fn(), json: jest.fn() }
+      return { text: jest.fn(), json: jest.fn(), status: 200, ok: true, statusText: 'OK' }
     }
   })
 

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -816,7 +816,6 @@ describe('Ajax', () => {
       const error = new Error('Network error')
       global.fetch = jest.fn().mockRejectedValue(error)
 
-      // Verifica que se puede capturar el error con catch
       let caught = false
       await ajax('http://example.com/').catch(e => {
         caught = true

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -775,4 +775,42 @@ describe('Ajax', () => {
       expect(spy).toHaveBeenCalledWith('http://example.com/', { method: 'POST', credentials: 'include', body: form, headers: {} })
     })
   })
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      jest.resetAllMocks()
+    })
+
+    test('rejects with error when fetch throws', async () => {
+      const error = new Error('Network error')
+      global.fetch = jest.fn().mockRejectedValue(error)
+
+      await expect(ajax('http://example.com/')).rejects.toThrow('Network error')
+    })
+
+    test('rejects with error when response is not ok (status 404)', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        text: jest.fn().mockResolvedValue('Not Found'),
+        json: jest.fn().mockResolvedValue({})
+      })
+
+      await expect(ajax('http://example.com/')).rejects.toThrow('HTTP error! Status: 404')
+    })
+
+    test('error is catchable via .catch()', async () => {
+      const error = new Error('Network error')
+      global.fetch = jest.fn().mockRejectedValue(error)
+
+      // Verifica que se puede capturar el error con catch
+      let caught = false
+      await ajax('http://example.com/').catch(e => {
+        caught = true
+        expect(e).toBe(error)
+      })
+      expect(caught).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
This pull request improves error handling in the `Helpers` class's AJAX functionality by making errors catchables with .catch(). The main focus is to make sure that failed HTTP requests and network issues are correctly surfaced as errors, and that these errors can be caught and handled as expected.

**Error handling improvements:**

* Enhanced the `ajax` method in `src/helpers.js` to throw detailed errors when the HTTP response is not OK, including status code and message from the response body if available.

**Test coverage:**

* Added a new test suite in `tests/helpers.test.js` to verify error handling, including cases where `fetch` throws, when the response is not OK (e.g., 404 status), and that errors are catchable with `.catch()`.

Fixes https://github.com/ralixjs/ralix/issues/107