### PR TITLE
[Improve] Skip sanitize empty string

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -219,7 +219,9 @@ export default class Helpers {
   }
 
   sanitize(html) {
-    return DOMPurify.sanitize(html)
+    if (typeof html === 'string' && html.trim() !== ''){
+      return DOMPurify.sanitize(html)
+    }
   }
 
   // Templates


### PR DESCRIPTION
**WHY?**
This pull request makes a small improvement to the `sanitize` method in the `Helpers` class to ensure that only non-empty strings are passed to `DOMPurify.sanitize`. This helps prevent unnecessary processing of empty or invalid input.