### PR TITLE
Allow use tags in sanitize

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -220,7 +220,7 @@ export default class Helpers {
 
   sanitize(html) {
     if (typeof html === 'string' && html.trim() !== ''){
-      return DOMPurify.sanitize(html)
+      return DOMPurify.sanitize(html, { ADD_TAGS: ['use'] })
     }
   }
 


### PR DESCRIPTION
This pull request makes a small adjustment to the `sanitize` method in the `Helpers` class. The change allows the `use` SVG tag to be preserved during HTML sanitization, which can be important for rendering certain SVG elements correctly.

- Updated the `sanitize` method in `Helpers` to allow the `use` SVG tag by passing `{ ADD_TAGS: ['use'] }` to `DOMPurify.sanitize`.