### PR TITLE
Allow insertHTML old approach

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -183,7 +183,11 @@ export default class Helpers {
     if (!el) return
 
     const defaults = { position: 'inner', sanitize: true }
-    options = Object.assign({}, defaults, options)
+
+    if (typeof options === 'string')
+      options = Object.assign({}, defaults, { position: options })
+    else
+      options = Object.assign({}, defaults, options)
 
     if (html instanceof Element) html = html.outerHTML
 

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -400,6 +400,12 @@ describe('DOM', () => {
       expect(document.body.innerHTML).toBe('<div>Some content for testing<span>After content</span></div><div></div>')
     })
 
+    test('old options approach should also work', () => {
+      insertHTML(element, '<span>After content</span>', 'end')
+
+      expect(document.body.innerHTML).toBe('<div>Some content for testing<span>After content</span></div><div></div>')
+    })
+
     test('render Element', () => {
       insertHTML(element, elem('p'), { position: 'end' })
 


### PR DESCRIPTION
This pull request updates the `insertHTML` helper to make its options parameter more flexible, to ensure backward compatibility with the previous usage pattern.