### PR TITLE
[Fix] Sanitize returns undefined on empty html content

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -223,9 +223,10 @@ export default class Helpers {
   }
 
   sanitize(html) {
-    if (typeof html === 'string' && html.trim() !== ''){
+    if (typeof html === 'string' && html.trim() === '')
+      return ''
+    else
       return DOMPurify.sanitize(html, { ADD_TAGS: ['use'] })
-    }
   }
 
   // Templates


### PR DESCRIPTION
This pull request makes a small change to the `sanitize` method. The method now returns an empty string if the input is an empty or whitespace-only string, instead of passing it to the sanitizer.